### PR TITLE
Allow to link Dev Dependencies as well

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -165,7 +165,7 @@ function projectFromFile(file, cb) {
 			exists: true,
 			deps: []
 		};
-		_.each(json.dependencies, function (version, name) {
+		_.each(_.extend({}, json.dependencies, json.devDependencies), function (version, name) {
 			if (shouldLink(version)) {
 				project.deps.push(name);
 				if (!projects[name]) {


### PR DESCRIPTION
While linking we need to make sure that the dev dependencies are also linked (eg. pulse-grunt-tasks)
